### PR TITLE
Check if player is online every update, not every 5 minutes

### DIFF
--- a/PersistentChalk/PersistentChalk.cs
+++ b/PersistentChalk/PersistentChalk.cs
@@ -1,4 +1,4 @@
-﻿using Cove.Server.Plugins;
+using Cove.Server.Plugins;
 using Cove.Server;
 using Cove.Server.Chalk;
 using System.Text.Json;
@@ -36,16 +36,17 @@ namespace PersistentChalk
         {
             base.onUpdate();
 
-            // auto save the chalk data every 5 minutes if a player is online
+            if (ParentServer.AllPlayers.Count > 0)
+                // At least 1 player is online, reset hadOfflineUpdate
+                hadOfflineUpdate = false;
+
+            // Only auto save the chalk data every 5 minutes if a player is online
             if (DateTimeOffset.UtcNow.ToUnixTimeSeconds() - lastUpdate <= 300)
                 return;
 
             lastUpdate = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-            if (ParentServer.AllPlayers.Count > 0)
-                // Players are online again, reset hadOfflineUpdate
-                hadOfflineUpdate = false;
-            else if (ParentServer.AllPlayers.Count == 0 && !hadOfflineUpdate)
+            if (ParentServer.AllPlayers.Count == 0 && !hadOfflineUpdate)
                 // We're doing a final update, mark as such
                 hadOfflineUpdate = true;
             else


### PR DESCRIPTION
There's a small chance that a player might join, make something, and leave, and this not getting saved